### PR TITLE
FUSETOOLS-1585 - Avoid having two times the same WizardPage

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/globalconfiguration/beans/BeanConfigUtil.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/globalconfiguration/beans/BeanConfigUtil.java
@@ -69,16 +69,15 @@ public class BeanConfigUtil {
 	/*
 	 * This code reused from org.fusesource.ide.camel.editor.properties.creators.AbstractClassBasedParameterUICreator in the createBrowseButton method
 	 */
-	public String handleNewClassWizard(IProject project, Shell shell) {
-		NewClassCreationWizard wiz = new NewClassCreationWizard();
-		wiz.addPages();
-		wiz.init(PlatformUI.getWorkbench(), new StructuredSelection(project));
-		NewClassWizardPage wp = (NewClassWizardPage) wiz.getStartingPage();
-		WizardDialog wd = new WizardDialog(shell, wiz);
-		wp.setAddComments(true, true);
-		setInitialPackageFrament(project, wp);
+	public String handleNewClassWizard(IProject project, Shell shell) {	
+		NewClassWizardPage ncwp = new NewClassWizardPage();
+		ncwp.setAddComments(true, true);
+		setInitialPackageFrament(project, ncwp);
+		NewClassCreationWizard newClassCreationWizard = new NewClassCreationWizard(ncwp, true);
+		newClassCreationWizard.init(PlatformUI.getWorkbench(), new StructuredSelection(project));
+		WizardDialog wd = new WizardDialog(shell, newClassCreationWizard);
 		if (Window.OK == wd.open()) {
-			String value = wp.getCreatedType().getFullyQualifiedName();
+			String value = ncwp.getCreatedType().getFullyQualifiedName();
 			if (value != null) {
 				return value;
 			}


### PR DESCRIPTION
Before the pages on the wizard are added twice in
org.fusesource.ide.camel.editor.globalconfiguration.beans.BeanConfigUtil.handleNewClassWizard(IProject,
Shell) , there is a addPages() called which is also called when
wizard.open() is called which was causing that nothing happened when
clicking "Next"
Now, it is called a single time. No next button is displayed.