### PR TITLE
Fusetools 2564 proposal improving wsdl2rest ui plugin

### DIFF
--- a/editor/features/org.fusesource.ide.camel.editor.feature/feature.xml
+++ b/editor/features/org.fusesource.ide.camel.editor.feature/feature.xml
@@ -4,9 +4,9 @@
       label="%featureName"
       version="10.3.0.qualifier"
       provider-name="%providerName"
+      plugin="org.fusesource.ide.tooling"
       license-feature="org.jboss.tools.foundation.license.feature"
-      license-feature-version="0.0.0"
-      plugin="org.fusesource.ide.tooling">
+      license-feature-version="0.0.0">
 
    <description url="http://tools.jboss.org/features/apachecamel.html">
       %description
@@ -19,10 +19,9 @@
    <license url="%licenseURL">
       %license
    </license>
- 
+
    <requires>
       <import feature="org.fusesource.ide.core.feature" version="10.0.0" match="greaterOrEqual"/>
-      
       <import plugin="org.eclipse.ui"/>
       <import plugin="org.eclipse.core.resources" version="3.9.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.runtime" version="3.10.0" match="greaterOrEqual"/>
@@ -138,6 +137,20 @@
 
    <plugin
          id="org.fusesource.ide.projecttemplates"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.fusesource.ide.wsdl2rest"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.fusesource.ide.wsdl2rest.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/.classpath
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/.classpath
@@ -6,7 +6,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-validator-1.4.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/commons-validator-1.6.jar"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/META-INF/MANIFEST.MF
@@ -31,10 +31,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/commons-validator-1.6.jar,
  .
-Export-Package: org.apache.commons.validator,
- org.apache.commons.validator.routines,
- org.apache.commons.validator.routines.checkdigit,
- org.apache.commons.validator.util,
- org.fusesource.ide.wsdl2rest.ui.internal,
+Export-Package: org.fusesource.ide.wsdl2rest.ui.internal,
  org.fusesource.ide.wsdl2rest.ui.wizard,
  org.fusesource.ide.wsdl2rest.ui.wizard.pages

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/META-INF/MANIFEST.MF
@@ -29,7 +29,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.m2e.maven.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: lib/commons-validator-1.4.0.jar,
+Bundle-ClassPath: lib/commons-validator-1.6.jar,
  .
 Export-Package: org.apache.commons.validator,
  org.apache.commons.validator.routines,

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/build.properties
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/build.properties
@@ -1,6 +1,5 @@
 source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/commons-validator-1.4.0.jar
+               lib/

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/pom.xml
@@ -12,14 +12,6 @@
 	<packaging>eclipse-plugin</packaging>
 	<name>Red Hat Fuse Tooling :: Camel Editor :: Plugins :: Wsdl2Rest UI</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>commons-validator</groupId>
-			<artifactId>commons-validator</artifactId>
-			<version>1.4.0</version>
-		</dependency>
-	</dependencies>
-
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
@@ -31,10 +23,16 @@
 						<id>copy</id>
 						<phase>generate-sources</phase>
 						<goals>
-							<goal>copy-dependencies</goal>
+							<goal>copy</goal>
 						</goals>
 						<configuration>
-							<excludeScope>system</excludeScope>
+							<artifactItems>
+								<artifactItem>
+									<groupId>commons-validator</groupId>
+									<artifactId>commons-validator</artifactId>
+									<version>1.6</version>
+								</artifactItem>
+							</artifactItems>
 							<outputDirectory>lib</outputDirectory>
 						</configuration>
 					</execution>

--- a/editor/plugins/org.fusesource.ide.wsdl2rest/build.properties
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest/build.properties
@@ -1,37 +1,4 @@
-source.. = src/
-output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               src/,\
-               lib/camel-spring-2.20.1.jar,\
-               lib/cxf-codegen-plugin-3.2.1.jar,\
-               lib/javaparser-core-2.5.1.jar,\
-               lib/velocity-1.7.jar,\
-               lib/args4j-2.33.jar,\
-               lib/javax.ws.rs-api-2.1.jar,\
-               lib/slf4j-api-1.7.22.jar,\
-               lib/cxf-core-3.2.1.jar,\
-               lib/cxf-tools-common-3.2.1.jar,\
-               lib/cxf-tools-wsdlto-core-3.2.1.jar,\
-               lib/cxf-tools-wsdlto-frontend-jaxws-3.2.1.jar,\
-               lib/stax2-api-3.1.4.jar,\
-               lib/wsdl4j-1.6.3.jar,\
-               lib/cxf-rt-wsdl-3.2.1.jar,\
-               lib/commons-collections-3.2.2.jar,\
-               lib/cxf-rt-databinding-jaxb-3.2.1.jar,\
-               lib/jaxb-core-2.2.11.jar,\
-               lib/cxf-tools-wsdlto-databinding-jaxb-3.2.1.jar,\
-               lib/jaxb-xjc-2.2.11.jar,\
-               lib/xml-resolver-1.2.jar,\
-               lib/xmlschema-core-2.2.2.jar,\
-               lib/cxf-tools-validator-3.2.1.jar,\
-               lib/ant-1.10.1.jar,\
-               lib/ant-launcher-1.10.1.jar,\
-               lib/ant-nodeps-1.8.1.jar,\
-               lib/cxf-tools-wsdlto-frontend-javascript-3.2.1.jar,\
-               templates/,\
-               lib/commons-lang-2.4.jar,\
-               lib/wsdl2rest-util.jar,\
-               lib/wsdl2rest-impl.jar,\
-               lib/woodstox-core-5.0.3.jar,\
-               lib/cxf-rt-bindings-soap-3.2.1.jar
+               lib/
+

--- a/editor/plugins/pom.xml
+++ b/editor/plugins/pom.xml
@@ -18,6 +18,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <module>org.fusesource.ide.launcher.ui</module>
                 <module>org.fusesource.ide.project</module>
                 <module>org.fusesource.ide.projecttemplates</module>
+                <module>org.fusesource.ide.wsdl2rest</module>
+                <module>org.fusesource.ide.wsdl2rest.ui</module>
 	</modules>
 </project>
 	


### PR DESCRIPTION
using copy instead of copy-dependencies to grab a single jar as the others were not on classpath anyway.
and some other modifications, see commit messages