### PR TITLE
FUSETOOLS-2873 - Work in progress - get rid of ids

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/RestElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/RestElement.java
@@ -10,7 +10,8 @@
  ******************************************************************************/ 
 package org.fusesource.ide.camel.model.service.core.model;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
@@ -26,7 +27,7 @@ import org.w3c.dom.NodeList;
 public class RestElement extends AbstractRestCamelModelElement {
 
 	public static final String REST_TAG = "rest"; //$NON-NLS-1$
-	private Map<String, AbstractCamelModelElement> restOperations = new HashMap<>();
+	private List<RestVerbElement> restOperations = new ArrayList<>();
 
 	/**
 	 * @param parent
@@ -37,14 +38,6 @@ public class RestElement extends AbstractRestCamelModelElement {
 		setUnderlyingMetaModelObject(new RestElementEIP());
 	}
 	
-	public RestElement(String name) {
-		super(null, null);
-		setUnderlyingMetaModelObject(new RestElementEIP());
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement#getKind(java.lang.String)
-	 */
 	@Override
 	public String getKind(String name) {
 		// due to the missing EIP as underlying meta model we have to tell AbstractCamelModelElement what
@@ -52,9 +45,6 @@ public class RestElement extends AbstractRestCamelModelElement {
 		return NODE_KIND_ATTRIBUTE;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement#parseAttributes()
-	 */
 	@Override
 	protected void parseAttributes() {
 		Eip eip = getUnderlyingMetaModelObject();
@@ -82,9 +72,6 @@ public class RestElement extends AbstractRestCamelModelElement {
 		return null;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement#shouldParseNode()
-	 */
 	@Override
 	protected boolean shouldParseNode() {
 		// we do want to parse REST contents
@@ -100,20 +87,17 @@ public class RestElement extends AbstractRestCamelModelElement {
 		for (int i=0; i<children.getLength(); i++) {
 			Node tmp = children.item(i);
 			if (tmp.getNodeType() != Node.ELEMENT_NODE) continue;
-			parseNode(tmp);
+			parseChildNode(tmp);
 		}
 	}
 
-	private void parseNode(Node node) {
+	private void parseChildNode(Node node) {
 		RestVerbElement rve = new RestVerbElement(this, node);
 		rve.initialize();
-		this.restOperations.put(rve.getId(), rve);
+		this.restOperations.add(rve);
 	}
 
-	/**
-	 * @return the restOperations
-	 */
-	public Map<String, AbstractCamelModelElement> getRestOperations() {
+	public List<RestVerbElement> getRestOperations() {
 		return this.restOperations;
 	}
 
@@ -127,7 +111,7 @@ public class RestElement extends AbstractRestCamelModelElement {
 	/**
 	 * @param restOperations the restOperations to set
 	 */
-	public void setRestOperations(Map<String, AbstractCamelModelElement> restOperations) {
+	public void setRestOperations(List<RestVerbElement> restOperations) {
 		this.restOperations = restOperations;
 	}
 	
@@ -136,11 +120,11 @@ public class RestElement extends AbstractRestCamelModelElement {
 	 * 
 	 * @param def
 	 */
-	public void addRestOperation(AbstractCamelModelElement def) {
-		if (restOperations.containsKey(def.getId())) {
+	public void addRestOperation(RestVerbElement def) {
+		if (restOperations.contains(def)) {
 			return;
 		}
-		restOperations.put(def.getId(), def);
+		restOperations.add(def);
 		boolean childExists = false;
 		for (int i=0; i<getXmlNode().getChildNodes().getLength(); i++) {
 			if(def.getXmlNode() != null && getXmlNode().getChildNodes().item(i).isEqualNode(def.getXmlNode())) {
@@ -164,8 +148,8 @@ public class RestElement extends AbstractRestCamelModelElement {
 	 * @param def
 	 */
 	public void removeRestOperation(AbstractCamelModelElement def, RestElement parent) {
-		if (this.restOperations.containsKey(def.getId())) {
-			this.restOperations.remove(def.getId());
+		if (this.restOperations.contains(def)) {
+			this.restOperations.remove(def);
 			boolean childExists = false;
 			for (int i=0; i<getXmlNode().getChildNodes().getLength(); i++) {
 				if(getXmlNode().getChildNodes().item(i).isEqualNode(def.getXmlNode())) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/restconfiguration/RestConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/restconfiguration/RestConfigEditor.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.fusesource.ide.camel.editor.restconfiguration;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -347,9 +346,7 @@ public class RestConfigEditor extends EditorPart implements ICamelModelListener,
 				clearUI();
 				
 				RestElement acme = (RestElement) event.getStructuredSelection().getFirstElement();
-				Iterator<AbstractCamelModelElement> iter = acme.getRestOperations().values().iterator();
-				while (iter.hasNext()) {
-					RestVerbElement rve = (RestVerbElement) iter.next();
+				for (RestVerbElement rve : acme.getRestOperations()) {
 					Element elChild = (Element) rve.getXmlNode();
 					String verbUri = elChild.getAttribute("uri"); //$NON-NLS-1$
 					Composite operation = createVerbComposite(restOpsSection, elChild.getTagName(), verbUri);


### PR DESCRIPTION
Proposal to get rid of ids:
some basic functionality seems to work. Might worth giving a try like that and see what is not working (I suspect add/remove operations but buttons are not enabled for now so can be fine for a first iteration)
- noticed a stacktrace but might be a matter of adding an if
java.lang.NullPointerException
	at org.apache.xerces.dom.NodeImpl.isEqualNode(Unknown Source)
	at org.apache.xerces.dom.ParentNode.isEqualNode(Unknown Source)
	at org.apache.xerces.dom.ElementImpl.isEqualNode(Unknown Source)
	at org.fusesource.ide.camel.editor.internal.CamelModelNotificationService.calculateRelatedPictogramElements(CamelModelNotificationService.java:53)
	at org.fusesource.ide.camel.editor.internal.CamelModelChangeListener.resourceSetChanged(CamelModelChangeListener.java:58)
	at org.eclipse.emf.transaction.impl.TransactionalEditingDomainImpl$1.run(TransactionalEditingDomainImpl.java:781)
	at org.eclipse.emf.transaction.impl.TransactionalEditingDomainImpl.runExclusive(TransactionalEditingDomainImpl.java:328)
	at org.eclipse.emf.transaction.impl.TransactionalEditingDomainImpl.postcommit(TransactionalEditingDomainImpl.java:771)
	at org.eclipse.emf.transaction.impl.TransactionalEditingDomainImpl.deactivate(TransactionalEditingDomainImpl.java:543)
	at org.eclipse.emf.transaction.impl.TransactionImpl.close(TransactionImpl.java:712)
	at org.eclipse.emf.transaction.impl.TransactionImpl.commit(TransactionImpl.java:474)
	at org.eclipse.emf.workspace.AbstractEMFOperation.execute(AbstractEMFOperation.java:155)
	at org.eclipse.core.commands.operations.DefaultOperationHistory.execute(DefaultOperationHistory.java:488)
	at org.eclipse.emf.workspace.impl.WorkspaceCommandStackImpl.doExecute(WorkspaceCommandStackImpl.java:208)
	at org.eclipse.emf.transaction.impl.AbstractTransactionalCommandStack.execute(AbstractTransactionalCommandStack.java:165)
	at org.eclipse.graphiti.ui.internal.editor.GFWorkspaceCommandStackImpl.execute(GFWorkspaceCommandStackImpl.java:97)
	at org.eclipse.emf.transaction.impl.AbstractTransactionalCommandStack.execute(AbstractTransactionalCommandStack.java:219)
	at org.fusesource.ide.camel.editor.CamelEditor$4.run(CamelEditor.java:610)
	at org.eclipse.swt.widgets.Synchronizer.syncExec(Synchronizer.java:233)
	at org.eclipse.ui.internal.UISynchronizer.syncExec(UISynchronizer.java:144)
	at org.eclipse.swt.widgets.Display.syncExec(Display.java:4889)
	at org.fusesource.ide.camel.editor.CamelEditor.updateModelFromSource(CamelEditor.java:621)
	at org.fusesource.ide.camel.editor.CamelEditor.pageChange(CamelEditor.java:497)
- I also noticed a lot of blinking UI when going back and forth to investigate
- currently the id is marked as mandatory, would need to modify that in properties/validation