### PR TITLE
FUSETOOLS-2564 - modify name of wsdl 2 rest wizard

### DIFF
--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/plugin.xml
@@ -9,7 +9,7 @@
             icon="icons/camel_project_16x16.png"
             hasPages="true"
             id="org.fusesource.ide.wsdl2rest.wizard"
-            name="WSDL to Camel Rest DSL Wizard">
+            name="Camel Rest DSL from WSDL">
       </wizard>
    </extension>
 

--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/readme.md
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/readme.md
@@ -7,7 +7,7 @@ In the project you will find an "example" directory that includes several files 
 1. Create a new Fuse Integration project. Leave it as a Blank project (Spring or Blueprint DSL).
 2. Create a new src/main/resources/wsdl directory.
 3. Copy the HelloService.wsdl file into the src/main/resources/wsdl directory.
-4. Select the project, click New->Other, and select the Red Hat Fuse->WSDL to Camel Rest DSL Wizard. 
+4. Select the project, click New->Other, and select the Red Hat Fuse->Camel Rest DSL from WSDL. 
 5. On the "Select Incoming WSDL and Project for Generated Output" page, click the "..." button beside the WSDL File field and select HelloService.wsdl.
 6. Click Next. 
 8. Click Finish. The Camel file and associated Java classes will be generated and the project will refresh. 


### PR DESCRIPTION
we are already in a "new" " Select a wizard", then I think that the "Wizard" at the end of the name is redundant.

![image](https://user-images.githubusercontent.com/1105127/39114578-85323bb6-46df-11e8-9f9a-c733ecf2161d.png)

As we are reading "New" <name of the wizard>, it is currently "New WSDL to Camel REST DSL Wizard"

I think that "New Camel Rest DSL from WSDL" is better. What do you think?
