### PR TITLE
FUSETOOLS-2564 - use .wsdl initial pattern to show wsdl file by default

### DIFF
--- a/editor/plugins/org.fusesource.ide.wsdl2rest.ui/src/org/fusesource/ide/wsdl2rest/ui/wizard/pages/Wsdl2RestWizardBasePage.java
+++ b/editor/plugins/org.fusesource.ide.wsdl2rest.ui/src/org/fusesource/ide/wsdl2rest/ui/wizard/pages/Wsdl2RestWizardBasePage.java
@@ -203,7 +203,7 @@ public abstract class Wsdl2RestWizardBasePage extends WizardPage {
 				};
 			}
 		};
-		dialog.setInitialPattern("*"); //$NON-NLS-1$
+		dialog.setInitialPattern("*.wsdl"); //$NON-NLS-1$
 		if (dialog.open() == FilteredResourcesSelectionDialog.OK) {
 			Object[] result = dialog.getResult();
 			if (result == null || result.length != 1 || !(result[0] instanceof IResource)) {


### PR DESCRIPTION
when opening, with this PR we have:
![image](https://user-images.githubusercontent.com/1105127/39124995-c931ad60-46fd-11e8-833e-67f9eba85925.png)
 instead of:
![image](https://user-images.githubusercontent.com/1105127/39125002-d18b1d84-46fd-11e8-96a7-a703b88c6e1b.png)
