### PR TITLE
FUSETOOLS-2873 - update cached model in Rest editor tab

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/restconfiguration/RestConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/restconfiguration/RestConfigEditor.java
@@ -142,14 +142,7 @@ public class RestConfigEditor extends EditorPart implements ICamelModelListener,
 		this.parent.setLayout(gl);
 
 		CamelFile designEditorModel = parentEditor.getDesignEditor().getModel();
-		if (designEditorModel != null) {
-			designEditorModel.addModelListener(this);
-			
-			if (designEditorModel.getRouteContainer() != null && 
-					designEditorModel.getRouteContainer() instanceof CamelContextElement) {
-				ctx = (CamelContextElement)designEditorModel.getRouteContainer();
-			}		
-		}
+		ctx = getCamelContext(designEditorModel);
 
 		createContents();
 
@@ -157,6 +150,18 @@ public class RestConfigEditor extends EditorPart implements ICamelModelListener,
 		if (designEditorModel != null) {
 			designEditorModel.addModelListener(this);
 		}
+	}
+
+	protected CamelContextElement getCamelContext(CamelFile designEditorModel) {
+		if (designEditorModel != null) {
+			designEditorModel.addModelListener(this);
+			
+			if (designEditorModel.getRouteContainer() != null && 
+					designEditorModel.getRouteContainer() instanceof CamelContextElement) {
+				return  (CamelContextElement)designEditorModel.getRouteContainer();
+			}		
+		}
+		return null;
 	}
 
 	@Override
@@ -170,7 +175,7 @@ public class RestConfigEditor extends EditorPart implements ICamelModelListener,
 
 	@Override
 	public void modelChanged() {
-		// empty
+		ctx = getCamelContext(parentEditor.getDesignEditor().getModel());
 	}
 
 	@Override
@@ -531,6 +536,7 @@ public class RestConfigEditor extends EditorPart implements ICamelModelListener,
 	}	
 	
 	public void reload() {
+		ctx = getCamelContext(parentEditor.getDesignEditor().getModel());
 		refreshRestConfigurationSection();
 		clearUI();
 		refreshRestSection();


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

proposal to fix the model synchronization issue.
Maybe more elegant solution can be found.

I noticed that the properties view is empty when switching back to the REST tab but I guess that it is a different issue